### PR TITLE
fix: keyword + space falls through to web search

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -127,7 +127,7 @@
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>


### PR DESCRIPTION
typing "wc " (keyword then space) immediately falls through to alfred's default web search instead of staying in the script filter. this makes the workflow unusable since you can't actually type a time string.

the issue is that `argumenttype` in the script filter is set to `0` (argument required). with this setting, alfred doesn't activate the script filter until at least one character of argument text is typed. in the gap between pressing space and typing the first character, alfred has no workflow claiming the input, so it drops to fallback web search.

changing `argumenttype` to `1` (argument optional) makes the script filter claim the alfred bar as soon as "wc " is typed. the script already handles empty input gracefully (shows "Invalid Time" prompt), so this doesn't break anything.

one-line change in info.plist: `argumenttype` 0 → 1